### PR TITLE
Bugfixes for UNIX A.out Loader

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/unixaout/UnixAoutHeader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/unixaout/UnixAoutHeader.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ghidra.app.util.bin.format.aout;
+package ghidra.app.util.bin.format.unixaout;
 
 import java.io.IOException;
 
@@ -23,7 +23,7 @@ import ghidra.app.util.bin.ByteProvider;
 
 public class UnixAoutHeader {
 
-    enum ExecutableType {
+    public enum ExecutableType {
         OMAGIC, NMAGIC, ZMAGIC, QMAGIC, CMAGIC, UNKNOWN
     }
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/unixaout/UnixAoutMachineType.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/unixaout/UnixAoutMachineType.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ghidra.app.util.bin.format.aout;
+package ghidra.app.util.bin.format.unixaout;
 
 public class UnixAoutMachineType {
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/unixaout/UnixAoutRelocationTableEntry.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/unixaout/UnixAoutRelocationTableEntry.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ghidra.app.util.bin.format.aout;
+package ghidra.app.util.bin.format.unixaout;
 
 /**
  * Represents the content of a single entry in the relocation table format used

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/unixaout/UnixAoutSymbolTableEntry.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/unixaout/UnixAoutSymbolTableEntry.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ghidra.app.util.bin.format.aout;
+package ghidra.app.util.bin.format.unixaout;
 
 /**
  * Represents the content of a single entry in the symbol table format used by
@@ -22,7 +22,7 @@ package ghidra.app.util.bin.format.aout;
  */
 public class UnixAoutSymbolTableEntry {
 
-    enum SymbolType { N_UNDF, N_ABS, N_TEXT, N_DATA, N_BSS, N_FN, N_EXT, UNKNOWN }
+    public enum SymbolType { N_UNDF, N_ABS, N_TEXT, N_DATA, N_BSS, N_FN, N_EXT, UNKNOWN }
 
     public long nameStringOffset;
     public String name;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/UnixAoutLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/UnixAoutLoader.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package ghidra.app.util.bin.format.aout;
+package ghidra.app.util.opinion;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,13 +23,13 @@ import ghidra.app.util.Option;
 import ghidra.app.util.OptionException;
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.ByteProvider;
-import ghidra.app.util.bin.format.aout.UnixAoutHeader.ExecutableType;
+import ghidra.app.util.bin.format.unixaout.UnixAoutHeader;
+import ghidra.app.util.bin.format.unixaout.UnixAoutHeader.ExecutableType;
+import ghidra.app.util.bin.format.unixaout.UnixAoutRelocationTableEntry;
+import ghidra.app.util.bin.format.unixaout.UnixAoutSymbolTableEntry;
 import ghidra.app.util.importer.MessageLog;
-import ghidra.app.util.opinion.AbstractProgramWrapperLoader;
-import ghidra.app.util.opinion.Loader;
-import ghidra.app.util.opinion.LoadSpec;
-import ghidra.framework.store.LockException;
 import ghidra.framework.model.DomainObject;
+import ghidra.framework.store.LockException;
 import ghidra.program.flatapi.FlatProgramAPI;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressFactory;

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/UnixAoutLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/UnixAoutLoader.java
@@ -343,32 +343,30 @@ public class UnixAoutLoader extends AbstractProgramWrapperLoader {
         for (Integer i = 0; i < this.symTab.size(); i++) {
             UnixAoutSymbolTableEntry symTabEntry = this.symTab.elementAt(i);
             try {
-                if (symTabEntry.value != 0) {
-                    if (symTabEntry.type == UnixAoutSymbolTableEntry.SymbolType.N_TEXT) {
-                        if (symTabEntry.isExt) {
-                            // Save the entry point to this function in a list. Disassembly should
-							// wait until after we've processed the relocation tables.
-                            Address funcAddr = this.textAddrSpace.getAddress(symTabEntry.value);
-                            this.localFunctions.put(funcAddr, symTabEntry.name);
-                        }
-                    } else if (symTabEntry.type == UnixAoutSymbolTableEntry.SymbolType.N_DATA) {
-                        this.api.createLabel(this.dataAddrSpace.getAddress(symTabEntry.value),
-							symTabEntry.name, this.namespace, true, SourceType.IMPORTED);
-
-                    } else if (symTabEntry.type == UnixAoutSymbolTableEntry.SymbolType.N_BSS) {
-                        // Save the symbols that are explicitly identified as being in .bss
-                        // to a list so that they can be labeled later (after we actually
-                        // create the .bss block, which must wait until after we total all
-                        // the space used by N_UNDF symbols; see below.)
-                        this.bssSymbols.put(symTabEntry.name, symTabEntry.value);
-
-                    } else if (symTabEntry.type == UnixAoutSymbolTableEntry.SymbolType.N_UNDF) {
-                        // This is a special case given by the A.out spec: if the linker cannot find
-                        // this symbol in any of the other binary files, then the fact that it is
-                        // marked as N_UNDF but has a non-zero value means that its value should be
-                        // interpreted as a size, and the linker should reserve space in .bss for it.
-                        this.possibleBssSymbols.put(symTabEntry.name, symTabEntry.value);
+                if (symTabEntry.type == UnixAoutSymbolTableEntry.SymbolType.N_TEXT) {
+                    if (symTabEntry.isExt) {
+                        // Save the entry point to this function in a list. Disassembly should
+                        // wait until after we've processed the relocation tables.
+                        Address funcAddr = this.textAddrSpace.getAddress(symTabEntry.value);
+                        this.localFunctions.put(funcAddr, symTabEntry.name);
                     }
+                } else if (symTabEntry.type == UnixAoutSymbolTableEntry.SymbolType.N_DATA) {
+                    this.api.createLabel(this.dataAddrSpace.getAddress(symTabEntry.value),
+                        symTabEntry.name, this.namespace, true, SourceType.IMPORTED);
+
+                } else if (symTabEntry.type == UnixAoutSymbolTableEntry.SymbolType.N_BSS) {
+                    // Save the symbols that are explicitly identified as being in .bss
+                    // to a list so that they can be labeled later (after we actually
+                    // create the .bss block, which must wait until after we total all
+                    // the space used by N_UNDF symbols; see below.)
+                    this.bssSymbols.put(symTabEntry.name, symTabEntry.value);
+
+                } else if (symTabEntry.type == UnixAoutSymbolTableEntry.SymbolType.N_UNDF) {
+                    // This is a special case given by the A.out spec: if the linker cannot find
+                    // this symbol in any of the other binary files, then the fact that it is
+                    // marked as N_UNDF but has a non-zero value means that its value should be
+                    // interpreted as a size, and the linker should reserve space in .bss for it.
+                    this.possibleBssSymbols.put(symTabEntry.name, symTabEntry.value);
                 }
             } catch (Exception e) {
                 e.printStackTrace();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/UnixAoutLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/UnixAoutLoader.java
@@ -366,7 +366,9 @@ public class UnixAoutLoader extends AbstractProgramWrapperLoader {
                     // this symbol in any of the other binary files, then the fact that it is
                     // marked as N_UNDF but has a non-zero value means that its value should be
                     // interpreted as a size, and the linker should reserve space in .bss for it.
-                    this.possibleBssSymbols.put(symTabEntry.name, symTabEntry.value);
+                    if (symTabEntry.value > 0) {
+                        this.possibleBssSymbols.put(symTabEntry.name, symTabEntry.value);
+                    }
                 }
             } catch (Exception e) {
                 e.printStackTrace();

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/UnixAoutLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/UnixAoutLoader.java
@@ -214,7 +214,7 @@ public class UnixAoutLoader extends AbstractProgramWrapperLoader {
             try {
                 InputStream stream = provider.getInputStream(fileOffset);
                 this.textBlock = this.program.getMemory().createInitializedBlock(
-					this.filename + ".text", address, stream, size, monitor, this.isOverlay);
+                        ".text", address, stream, size, monitor, this.isOverlay);
                 this.textBlock.setRead(true);
                 this.textBlock.setWrite(false);
                 this.textBlock.setExecute(true);
@@ -243,7 +243,7 @@ public class UnixAoutLoader extends AbstractProgramWrapperLoader {
             try {
                 InputStream stream = provider.getInputStream(fileOffset);
                 this.dataBlock = program.getMemory().createInitializedBlock(
-                                     this.filename + ".data", address, stream, size, monitor, this.isOverlay);
+                        ".data", address, stream, size, monitor, this.isOverlay);
                 this.dataBlock.setRead(true);
                 this.dataBlock.setWrite(true);
                 this.dataBlock.setExecute(false);
@@ -291,7 +291,7 @@ public class UnixAoutLoader extends AbstractProgramWrapperLoader {
                 this.program.getAddressFactory().getDefaultAddressSpace().getAddress(bssAddrVal);
             try {
                 this.bssBlock = this.program.getMemory().createUninitializedBlock(
-                    this.filename + ".bss", bssAddr, totalBssSize, this.isOverlay);
+                        ".bss", bssAddr, totalBssSize, this.isOverlay);
                 this.bssAddrSpace = bssBlock.getStart().getAddressSpace();
                 this.bssBlock.setRead(true);
                 this.bssBlock.setWrite(true);

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/UnixAoutLoader.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/UnixAoutLoader.java
@@ -554,7 +554,7 @@ public class UnixAoutLoader extends AbstractProgramWrapperLoader {
         this.log = log;
         this.api = new FlatProgramAPI(program, monitor);
         this.header = new UnixAoutHeader(provider, !this.bigEndian);
-        this.filename = provider.getFile().getName();
+        this.filename = provider.getFSRL().getName();
         this.isOverlay = (header.getExecutableType() == ExecutableType.OMAGIC);
 
         try {


### PR DESCRIPTION
Just a bunch of stuff I've stumbled upon while trying to use your loader on vintage artifacts from Debian Buzz (1.1)'s a.out toolchain (https://archive.debian.org/debian/dists/buzz/main/binary-i386/devel/libc4-dev-4.6.27-15.deb), especially `/usr/i486-linuxaout/lib/libc.a`.

I'm fine with squashing these commits into 479d8fed5fd755ac713bab2342dcf6108be2b4df, no point polluting Ghidra's git history with fixup commits in your PR.